### PR TITLE
Implement weekly simulation APIs and standings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,19 @@ pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
 
-The API will be available at `http://localhost:8000`, and the `/health` endpoint returns `{ "status": "ok" }` when running.
+The API will be available at `http://localhost:8000`. Key endpoints now include:
+
+| Endpoint | Description |
+| --- | --- |
+| `GET /teams` | List all NFL teams in the simulation. |
+| `POST /simulate-week` | Simulate an entire week, returning box scores, player stats, injuries, and narratives. |
+| `GET /games/week/{week}` | Retrieve the saved box scores for a specific week. |
+| `GET /standings` | Compute league standings from the played games. |
+| `GET /free-agents` / `POST /teams/{teamId}/sign` | Manage free agent signings. |
+| `POST /trade` | Execute validated trades between teams. |
+| `GET/POST /teams/{teamId}/depth-chart` | Inspect or update depth chart assignments. |
+
+All endpoints return deterministic placeholder data sourced from the SQLite database so the frontend can render consistent results while development continues.
 
 ### Frontend
 
@@ -42,3 +54,13 @@ python database/load_data.py
 ```
 
 The command initializes `database/nfl_gm_sim.db` using the schema defined in `database/schema.sql` and seeds the tables with the placeholder roster and free-agent data found in `shared/data`.
+
+### Running the test suite
+
+Backend tests rely on the seeded SQLite database. From the repository root run:
+
+```bash
+pytest
+```
+
+The tests cover week simulations, free agency, trades, standings, and box score retrievals.

--- a/backend/app/services/box_score_service.py
+++ b/backend/app/services/box_score_service.py
@@ -253,4 +253,47 @@ class BoxScoreService:
             parts.append("No impact stats recorded")
         return ", ".join(parts), weight
 
+    def _game_events(self, connection, game_id: int) -> list[dict[str, Any]]:
+        rows = connection.execute(
+            """
+            SELECT
+                sequence,
+                quarter,
+                clock,
+                team_id,
+                player_id,
+                description,
+                highlight_type,
+                impact,
+                points,
+                home_score_after,
+                away_score_after
+            FROM game_events
+            WHERE game_id = ?
+            ORDER BY sequence
+            """,
+            (game_id,),
+        ).fetchall()
+
+        plays: list[dict[str, Any]] = []
+        for row in rows:
+            plays.append(
+                {
+                    "sequence": row["sequence"],
+                    "quarter": row["quarter"],
+                    "clock": row["clock"],
+                    "teamId": row["team_id"],
+                    "playerId": row["player_id"],
+                    "description": row["description"],
+                    "type": row["highlight_type"],
+                    "impact": row["impact"],
+                    "points": row["points"],
+                    "score": {
+                        "home": row["home_score_after"],
+                        "away": row["away_score_after"],
+                    },
+                }
+            )
+        return plays
+
 

--- a/shared/utils/parsers.py
+++ b/shared/utils/parsers.py
@@ -5,18 +5,26 @@ from typing import Iterable
 
 
 def _read_lines(path: Path) -> Iterable[str]:
+    if not path.exists():
+        return []
+
+    lines: list[str] = []
     for line in path.read_text().splitlines():
         line = line.strip()
         if not line or line.startswith("#"):
             continue
-        yield line
+        lines.append(line)
+    return lines
 
 
 def parse_ratings(path: str | Path) -> list[dict[str, str]]:
     path = Path(path)
     players: list[dict[str, str]] = []
     for row in _read_lines(path):
-        player_id, name, position, overall, team_abbr, age = row.split("|")
+        parts = row.split("|")
+        if len(parts) != 6:
+            continue
+        player_id, name, position, overall, team_abbr, age = parts
         players.append(
             {
                 "id": int(player_id),
@@ -27,14 +35,33 @@ def parse_ratings(path: str | Path) -> list[dict[str, str]]:
                 "age": int(age),
             }
         )
-    return players
+
+    if players:
+        return players
+
+    # Fallback data used when the ratings feed has not been prepared yet.
+    return [
+        {"id": 1, "name": "Josh Allen", "position": "QB", "overall_rating": 96, "team_abbr": "BUF", "age": 28},
+        {"id": 2, "name": "Stefon Diggs", "position": "WR", "overall_rating": 94, "team_abbr": "BUF", "age": 30},
+        {"id": 3, "name": "James Cook", "position": "RB", "overall_rating": 84, "team_abbr": "BUF", "age": 25},
+        {"id": 4, "name": "Joe Burrow", "position": "QB", "overall_rating": 95, "team_abbr": "CIN", "age": 28},
+        {"id": 5, "name": "Ja'Marr Chase", "position": "WR", "overall_rating": 93, "team_abbr": "CIN", "age": 25},
+        {"id": 6, "name": "Tee Higgins", "position": "WR", "overall_rating": 90, "team_abbr": "CIN", "age": 26},
+        {"id": 7, "name": "Joe Mixon", "position": "RB", "overall_rating": 88, "team_abbr": "CIN", "age": 28},
+        {"id": 8, "name": "Dawson Knox", "position": "TE", "overall_rating": 82, "team_abbr": "BUF", "age": 27},
+        {"id": 9, "name": "Von Miller", "position": "EDGE", "overall_rating": 88, "team_abbr": "BUF", "age": 35},
+        {"id": 10, "name": "Logan Wilson", "position": "LB", "overall_rating": 85, "team_abbr": "CIN", "age": 26},
+    ]
 
 
 def parse_depth_charts(path: str | Path) -> list[dict[str, str]]:
     path = Path(path)
     entries: list[dict[str, str]] = []
     for row in _read_lines(path):
-        team_abbr, position, player_id, order = row.split("|")
+        parts = row.split("|")
+        if len(parts) != 4:
+            continue
+        team_abbr, position, player_id, order = parts
         entries.append(
             {
                 "team_abbr": team_abbr,
@@ -43,14 +70,32 @@ def parse_depth_charts(path: str | Path) -> list[dict[str, str]]:
                 "order": int(order),
             }
         )
-    return entries
+
+    if entries:
+        return entries
+
+    return [
+        {"team_abbr": "BUF", "position": "QB", "player_id": 1, "order": 1},
+        {"team_abbr": "BUF", "position": "RB", "player_id": 3, "order": 1},
+        {"team_abbr": "BUF", "position": "WR", "player_id": 2, "order": 1},
+        {"team_abbr": "BUF", "position": "TE", "player_id": 8, "order": 1},
+        {"team_abbr": "BUF", "position": "EDGE", "player_id": 9, "order": 1},
+        {"team_abbr": "CIN", "position": "QB", "player_id": 4, "order": 1},
+        {"team_abbr": "CIN", "position": "RB", "player_id": 7, "order": 1},
+        {"team_abbr": "CIN", "position": "WR", "player_id": 5, "order": 1},
+        {"team_abbr": "CIN", "position": "WR", "player_id": 6, "order": 2},
+        {"team_abbr": "CIN", "position": "LB", "player_id": 10, "order": 1},
+    ]
 
 
 def parse_free_agents(path: str | Path) -> list[dict[str, str]]:
     path = Path(path)
     agents: list[dict[str, str]] = []
     for row in _read_lines(path):
-        player_id, name, position, overall, age = row.split("|")
+        parts = row.split("|")
+        if len(parts) != 5:
+            continue
+        player_id, name, position, overall, age = parts
         agents.append(
             {
                 "id": int(player_id),
@@ -60,7 +105,14 @@ def parse_free_agents(path: str | Path) -> list[dict[str, str]]:
                 "age": int(age),
             }
         )
-    return agents
+
+    if agents:
+        return agents
+
+    return [
+        {"id": 9001, "name": "Julio Jones", "position": "WR", "overall_rating": 90, "age": 36},
+        {"id": 9002, "name": "Ndamukong Suh", "position": "DL", "overall_rating": 88, "age": 38},
+    ]
 
 
 def parse_schedule(path: str | Path) -> list[dict[str, str]]:
@@ -69,7 +121,10 @@ def parse_schedule(path: str | Path) -> list[dict[str, str]]:
     path = Path(path)
     schedule: list[dict[str, str]] = []
     for row in _read_lines(path):
-        week, home_abbr, away_abbr = row.split("|")
+        parts = row.split("|")
+        if len(parts) != 3:
+            continue
+        week, home_abbr, away_abbr = parts
         schedule.append(
             {
                 "week": int(week),
@@ -77,4 +132,11 @@ def parse_schedule(path: str | Path) -> list[dict[str, str]]:
                 "away_abbr": away_abbr,
             }
         )
-    return schedule
+
+    if schedule:
+        return schedule
+
+    return [
+        {"week": 1, "home_abbr": "BUF", "away_abbr": "CIN"},
+        {"week": 2, "home_abbr": "CIN", "away_abbr": "BUF"},
+    ]

--- a/tests/backend/test_league.py
+++ b/tests/backend/test_league.py
@@ -1,0 +1,30 @@
+from fastapi.testclient import TestClient
+
+
+def test_week_box_scores_and_standings(api_client: TestClient) -> None:
+    simulation = api_client.post("/simulate-week", json={"week": 1})
+    assert simulation.status_code == 200
+    sim_payload = simulation.json()
+    summary_count = len(sim_payload["summaries"])
+
+    week_box_scores = api_client.get("/games/week/1")
+    assert week_box_scores.status_code == 200
+    weekly = week_box_scores.json()
+    assert isinstance(weekly, list)
+    assert len(weekly) == summary_count
+
+    standings_response = api_client.get("/standings")
+    assert standings_response.status_code == 200
+    standings = standings_response.json()
+
+    assert standings["updatedThroughWeek"] >= 1
+    assert len(standings["divisions"]) > 0
+    assert len(standings["teams"]) > 0
+
+    total_results = sum(
+        entry["wins"] + entry["losses"] + entry["ties"] for entry in standings["teams"]
+    )
+    assert total_results > 0
+    first_division = standings["divisions"][0]
+    assert "conference" in first_division and "teams" in first_division
+    assert len(first_division["teams"]) >= 1

--- a/tests/backend/test_simulation.py
+++ b/tests/backend/test_simulation.py
@@ -21,12 +21,18 @@ def test_simulate_week_quick_mode(api_client: TestClient) -> None:
     assert data["week"] == 1
     assert data["mode"] == "quick"
     assert len(data["summaries"]) >= 1
+    assert len(data["games"]) >= 1
     assert isinstance(data["playByPlay"], list)
 
     first_summary = data["summaries"][0]
     assert "homeTeam" in first_summary and "awayTeam" in first_summary
     assert first_summary["homeTeam"]["points"] >= 0
     assert isinstance(first_summary["keyPlayers"], list)
+
+    first_game = data["games"][0]
+    assert "teamStats" in first_game and "playerStats" in first_game
+    assert isinstance(first_game["injuries"], list)
+    assert first_game["plays"] == []
 
     game_id = first_summary["gameId"]
     with _db_connection() as connection:
@@ -66,9 +72,12 @@ def test_simulate_week_detailed_mode_creates_play_log(api_client: TestClient) ->
     assert data["mode"] == "detailed"
     assert len(data["summaries"]) >= 1
     assert len(data["playByPlay"]) > 0
+    assert len(data["games"]) >= 1
 
     first_summary = data["summaries"][0]
     game_id = first_summary["gameId"]
+    detailed_game = next(game for game in data["games"] if game["gameId"] == game_id)
+    assert len(detailed_game["plays"]) > 0
 
     with _db_connection() as connection:
         event_rows = connection.execute(


### PR DESCRIPTION
## Summary
- expand the weekly simulation route to return per-game breakdowns, injuries, and narratives and add `/games/week/{week}` plus `/standings`
- expose game event payloads through the box score service and enrich simulation bookkeeping with player stats and team context
- harden data parsers with deterministic fallback rosters/schedules, document the new endpoints, and add regression tests for standings and simulation payloads

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68df03a96aa88323a5b4d5cc7018c4a1