### PR TITLE
Update README with health endpoint and database seeding workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # NFL GM Simulator Monorepo
 
-This repository contains the early scaffolding for the NFL GM Simulator project. The monorepo is organized into dedicated workspaces for the FastAPI backend, React + Tailwind frontend, database assets, and shared utilities used across services.
+This repository contains the scaffolding for the NFL GM Simulator project. The
+monorepo is organized into dedicated workspaces for the FastAPI backend, React +
+Tailwind frontend, database assets, and shared utilities used across services.
 
 ## Project Structure
 
-```
+```text
 backend/   # FastAPI application
 frontend/  # React + Tailwind dashboard
 database/  # SQLite schema, initialization, and loaders
@@ -23,19 +25,25 @@ pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
 
-The API will be available at `http://localhost:8000`. Key endpoints now include:
+The API will be available at `http://localhost:8000`, and `GET /health` returns
+`{ "status": "ok" }` when the service is running. After seeding the database, the
+backend serves deterministic placeholder data so the frontend can render consistent
+results while development continues. Key endpoints now include:
 
-| Endpoint | Description |
-| --- | --- |
-| `GET /teams` | List all NFL teams in the simulation. |
-| `POST /simulate-week` | Simulate an entire week, returning box scores, player stats, injuries, and narratives. |
-| `GET /games/week/{week}` | Retrieve the saved box scores for a specific week. |
-| `GET /standings` | Compute league standings from the played games. |
-| `GET /free-agents` / `POST /teams/{teamId}/sign` | Manage free agent signings. |
-| `POST /trade` | Execute validated trades between teams. |
-| `GET/POST /teams/{teamId}/depth-chart` | Inspect or update depth chart assignments. |
-
-All endpoints return deterministic placeholder data sourced from the SQLite database so the frontend can render consistent results while development continues.
+| Method | Endpoint | Description |
+| --- | --- | --- |
+| GET | `/teams` | List every NFL team and its current roster. |
+| GET | `/teams/{teamId}` | Retrieve a single team including its players. |
+| GET | `/teams/{teamId}/stats` | Starter stats generated from simulations. |
+| GET | `/players` | Browse the player pool; filter by `teamId` or `status`. |
+| GET | `/free-agents` | View the current free-agent market for the season. |
+| POST | `/teams/{teamId}/sign` | Sign a free agent while checking depth rules. |
+| GET/POST | `/teams/{teamId}/depth-chart` | Inspect or update depth slots. |
+| POST | `/trade/validate` | Validate a proposed trade against roster rules. |
+| POST | `/trade` | Execute an approved trade and persist roster changes. |
+| GET | `/games` | Review scheduled or completed games by week or team. |
+| GET | `/games/{gameId}` | Inspect one scheduled or completed game summary. |
+| POST | `/simulate-week` | Simulate a week with scores, stats, and narratives. |
 
 ### Frontend
 
@@ -45,15 +53,20 @@ npm install
 npm run dev
 ```
 
-Open the dashboard at `http://localhost:5173` to view the placeholder GM control center UI.
+Open the dashboard at `http://localhost:5173` to view the placeholder GM
+control center UI.
 
 ### Database Seeding
 
 ```bash
-python database/load_data.py
+make seed
 ```
 
-The command initializes `database/nfl_gm_sim.db` using the schema defined in `database/schema.sql` and seeds the tables with the placeholder roster and free-agent data found in `shared/data`.
+The `make seed` target provisions the SQLite database using the schema defined in
+`database/schema.sql` and populates the tables with the roster, free-agent,
+schedule, and narrative placeholder data from `shared/data`. Once seeded,
+endpoints such as `/teams`, `/free-agents`, `/trade`, `/games`, and `/simulate-week`
+read from the database for deterministic responses.
 
 ### Running the test suite
 


### PR DESCRIPTION
## Summary
- document the backend health check and expanded endpoint table for the seeded API
- update the database seeding instructions to reflect the `make seed` target and data-driven flow

## Testing
- npx --yes markdownlint-cli@0.39.0 README.md

------
https://chatgpt.com/codex/tasks/task_e_68e040d18c0083239e10b8b5b6b00726