### PR TITLE
Handle UTF-8 decoding in parsers

### DIFF
--- a/shared/utils/parsers.py
+++ b/shared/utils/parsers.py
@@ -9,11 +9,12 @@ def _read_lines(path: Path) -> Iterable[str]:
         return []
 
     lines: list[str] = []
-    for line in path.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        lines.append(line)
+    with path.open(encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            lines.append(line)
     return lines
 
 

--- a/tests/shared/utils/fixtures/ratings_non_ascii.txt
+++ b/tests/shared/utils/fixtures/ratings_non_ascii.txt
@@ -1,0 +1,2 @@
+# Example ratings file with non-ASCII characters
+1|José Pérez|QB|90|MEX|29

--- a/tests/shared/utils/test_parsers.py
+++ b/tests/shared/utils/test_parsers.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from shared.utils.parsers import parse_ratings
+
+
+def test_parse_ratings_handles_non_ascii(tmp_path: Path) -> None:
+    fixture_src = Path(__file__).parent / "fixtures" / "ratings_non_ascii.txt"
+    fixture_dst = tmp_path / "ratings.txt"
+    fixture_dst.write_bytes(fixture_src.read_bytes())
+
+    players = parse_ratings(fixture_dst)
+
+    assert players == [
+        {
+            "id": 1,
+            "name": "José Pérez",
+            "position": "QB",
+            "overall_rating": 90,
+            "team_abbr": "MEX",
+            "age": 29,
+        }
+    ]


### PR DESCRIPTION
## Summary
- ensure `_read_lines` opens files with UTF-8 encoding and replacement to avoid locale-specific decoding errors
- add a ratings parser regression test that covers non-ASCII data via a text fixture

## Testing
- `PYTHONPATH=. pytest tests/shared/utils/test_parsers.py`
- `PYTHONPATH=. python database/load_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68e0af95c3d083238ca91f41003fb536