### PR TITLE
Fix tie-breaking for clamped scores and add simulation tests

### DIFF
--- a/backend/app/services/simulation_service.py
+++ b/backend/app/services/simulation_service.py
@@ -192,8 +192,17 @@ class SimulationService:
         away_score = self._clamp_score(away_points)
 
         if home_score == away_score:
-            home_score += 3 if rng.random() > 0.5 else -3
-            home_score = self._clamp_score(home_score)
+            adjustment = 3 if rng.random() > 0.5 else -3
+            for delta in (adjustment, -adjustment):
+                candidate = self._clamp_score(home_score + delta)
+                if candidate != away_score:
+                    home_score = candidate
+                    break
+            else:
+                fallback = self._clamp_score(away_score - adjustment)
+                if fallback == home_score:
+                    fallback = self._clamp_score(away_score + adjustment)
+                away_score = fallback
         return home_score, away_score
 
     def _clamp_score(self, value: float) -> int:


### PR DESCRIPTION
## Summary
- extend simulation core tests with tie-breaking cases, impact labeling coverage, and a score breakdown conservation property
- adjust score generation tie-breaking so clamped results still yield distinct winners

## Testing
- pytest backend/tests/test_sim_core.py -q
- pytest -q *(fails: seed ingestion tests require CSV columns/tables not present in local fixture)*

------
https://chatgpt.com/codex/tasks/task_e_68e1593796208323bb6e54019cd52eec